### PR TITLE
fix: update lambda runtime to supported version

### DIFF
--- a/infra/stack/backend-lambda-stack.ts
+++ b/infra/stack/backend-lambda-stack.ts
@@ -19,7 +19,7 @@ export class BackendLambdaStack extends base.BaseStack {
     private createLambdaFunction(baseName: string): lambda.Function {
         const func = new lambda.Function(this, `${baseName}-func`, {
             functionName: `${this.projectPrefix}-${baseName}-func`,
-            runtime: lambda.Runtime.NODEJS_12_X,
+            runtime: lambda.Runtime.NODEJS_16_X,
             code: lambda.Code.fromAsset(`codes/lambda/${baseName}/src`),
             handler: 'index.handle',
         });

--- a/script/setup_initial.sh
+++ b/script/setup_initial.sh
@@ -36,7 +36,6 @@ echo .
 
 echo ==--------BootstrapCDKEnvironment---------==
 cdk bootstrap aws://$ACCOUNT/$REGION
-cdk bootstrap aws://$ACCOUNT/$REGION2
 echo .
 echo .
 


### PR DESCRIPTION
This change updates to a supported Lambda runtime and removes the unused bootstrap environment.

*Description of changes:*
NodeJS 12.x is no longer supported by AWS lambda. As a result, attempts to deploy a new lambda using the runtime result in failures. In addition, I could not find any references to `REGION2` when following the README instructions. I've removed that bootstrap so that the `setup_initial.sh` script could run successfully.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
